### PR TITLE
fixed check/in/out to work with Maven repository layout

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -50,11 +50,10 @@ if [ -n "$paramRegex" ]; then
 fi
 
 final_url=$(echo "$args_security" " $args_url")
-# echo $final_url
 
 if [ -z "$version" ]; then
   echo "empty version - return current version"
-  artifactory_current_version "$final_url" "$regex" >&3
+  artifactory_current_version "$final_url" >&3
 else
-  check_version "$final_url" "$regex" "$version" >&3
+  check_version "$final_url" "$version" >&3
 fi

--- a/assets/in
+++ b/assets/in
@@ -74,9 +74,7 @@ if [ -z "$file" ]; then
   exit 1
 fi
 
-args_url="$endpoint$repository/$file"
-
-# echo $args_security "-O" "$args_url"
+args_url="$endpoint$repository/$version/$file"
 curl $args_security "-O" "$args_url"
 
 echo $file_json | jq '.[].version | {version: {version: .}}' >&3

--- a/assets/out
+++ b/assets/out
@@ -48,8 +48,14 @@ fi
 
 abs_file=$(ls $file)
 filename=$(basename "$abs_file")
+# echo $file $regex
+version=$(applyRegex_version $regex $filename)
 
-
+# artifactory/maven repo layout 
+# [org]/[module]/[baseRev](-[folderItegRev])/[module]-[baseRev](-[fileItegRev])(-[classifier]).[ext]
+# org = $repository, i.e. "com/acme"
+# module = $folder
+# baseRev = regexed version, i.e. "0.1"
 args_url="$endpoint"
 args_url="$args_url$repository"
 
@@ -57,6 +63,8 @@ if [ -n "$folder" ]; then
 	echo "adding parameter folder"
 	args_url="$args_url/$folder"
 fi
+
+args_url="$args_url/$version"
 
 args_url="$args_url/$filename"
 
@@ -69,12 +77,8 @@ trueValue="true"
 
 # echo "########## $filename, $file"
 
-# echo $args_security "-T $abs_file $args_url "
+#echo $args_security "-T $abs_file $args_url "
 curl $args_security "-T$abs_file" "$args_url"
-
-
-# echo $file $regex
-version=$(applyRegex_version $regex $filename)
 
 jq -n "{
   version: {version: $(echo $version | jq -R .)}


### PR DESCRIPTION
fixes #10 

this fixes the resource to work with Maven2 repository layout where artifacts are located in version folders
```
[org]/[module]/[baseRev](-[folderItegRev])/[module]-[baseRev](-[fileItegRev])(-[classifier]).[ext]
e.g.
com/acme/foobar/1.0/foobar-1.0.jar
```
current implementation would put/expect the artifacts in a single folder (com/acme/foobar/foobar-1.0.jar) which doesnt work together with other buildtools