### PR TITLE
Add endpoint error checks to in and out assets

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -77,6 +77,14 @@ fi
 args_url="$endpoint$repository/$file"
 
 # echo $args_security "-O" "$args_url"
-curl $args_security "-O" "$args_url"
+MSG=`curl $args_security "-O" "$args_url"`
+
+if echo $MSG | jq -e 'has("errors")' >/dev/null ; then
+  echo "Endpoint returned server error:"
+  echo $MSG | jq -c '.errors[0]'
+  exit 1
+else
+  echo $MSG
+fi
 
 echo $file_json | jq '.[].version | {version: {version: .}}' >&3

--- a/assets/out
+++ b/assets/out
@@ -70,8 +70,15 @@ trueValue="true"
 # echo "########## $filename, $file"
 
 # echo $args_security "-T $abs_file $args_url "
-curl $args_security "-T$abs_file" "$args_url"
+MSG=`curl $args_security "-T$abs_file" "$args_url"`
 
+if echo $MSG | jq -e 'has("errors")' >/dev/null ; then
+  echo "Endpoint returned server error:"
+  echo $MSG | jq -c '.errors[0]'
+  exit 1
+else
+  echo $MSG
+fi
 
 # echo $file $regex
 version=$(applyRegex_version $regex $filename)


### PR DESCRIPTION
The curl commands to artifactory can return fine but with error msgs imbedded in the returned json.  

These changes look for a key 'errors', fails the test, and outputs the returned error.

use/test case for out asset:

attempt to deploy a version that already exists in artifactory, using a user account without delete permissions, artifactory will return:

{
  "errors" : [ {
    "status" : 403,
    "message" : "Not enough permissions to overwrite artifact '_REPO_:_PACKAGE_VERSION_.rpm' (user 'XXXXX' needs DELETE permission)."
  } ]
}