### PR TITLE
Add skip_download param with tests. Fixes #13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,21 @@ resources:
 
 ## Source Configuration
 
-* `endpoint`: *Required.* The Artifactory REST API endpoint. eg. http://YOUR-HOST_NAME:8081/artifactory.  
-* `repository`: *Required.* The Artifactory repository which includes any folder path, must contain a leading '/'. ```eg. /generic/product/pcf```  
-* `regex`: *Required.* Regular expression used to extract artifact version, must contain 'version' group. ```E.g. myapp-(?<version>.*).tar.gz```  
-* `username`: *Optional.* Username for HTTP(S) auth when accessing an authenticated repository  
-* `password`: *Optional.* Password for HTTP(S) auth when accessing an authenticated repository  
-* `skip_ssl_verification`: *Optional.* Skip ssl verification when connecting to Artifactory's APIs. Values: ```true``` or ```false```(default).  
+* `endpoint`: *Required.* The Artifactory REST API endpoint. eg. http://YOUR-HOST_NAME:8081/artifactory.
+* `repository`: *Required.* The Artifactory repository which includes any folder path, must contain a leading '/'. ```eg. /generic/product/pcf```
+* `regex`: *Required.* Regular expression used to extract artifact version, must contain 'version' group. ```E.g. myapp-(?<version>.*).tar.gz```
+* `username`: *Optional.* Username for HTTP(S) auth when accessing an authenticated repository
+* `password`: *Optional.* Password for HTTP(S) auth when accessing an authenticated repository
+* `skip_ssl_verification`: *Optional.* Skip ssl verification when connecting to Artifactory's APIs. Values: ```true``` or ```false```(default).
 
 ## Parameter Configuration
 
-* `file`: *Required for put* The file to upload to Artifactory  
-* `regex`: *Optional* overrides the source regex  
-* `folder`: *Optional.* appended to the repository in source - must start with forward slash /  
+* `file`: *Required for put* The file to upload to Artifactory
+* `regex`: *Optional* overrides the source regex
+* `folder`: *Optional.* appended to the repository in source - must start with forward slash /
+* `skip_download`: *Optional.* skip download of file. Useful for improving put performance by skipping the implicit get step using [get_params](https://concourse.ci/put-step.html#put-step-get-params).
 
-Saving/deploying an artifact to Artifactory in a pipeline job:  
+Saving/deploying an artifact to Artifactory in a pipeline job:
 
 ``` yaml
   jobs:
@@ -65,7 +66,7 @@ Saving/deploying an artifact to Artifactory in a pipeline job:
       params: { file: ./build/myapp-*.txt }
 ```
 
-Retrieving an artifact from Artifactory in a pipeline job:  
+Retrieving an artifact from Artifactory in a pipeline job:
 
 ``` yaml
 jobs:
@@ -88,7 +89,7 @@ jobs:
         - "Use file(s) from ./file-repository here..."
 ```
 
-See [pipeline.yml](https://github.com/pivotalservices/artifactory-resource/blob/master/pipeline.yml) for an example of a full pipeline definition file.  
+See [pipeline.yml](https://github.com/pivotalservices/artifactory-resource/blob/master/pipeline.yml) for an example of a full pipeline definition file.
 
 ## Resource behavior
 

--- a/assets/in
+++ b/assets/in
@@ -30,6 +30,7 @@ repository=$(jq -r '.source.repository // ""' < $payload)
 file=$(jq -r '.params.file // ""' < $payload)
 folder=$(jq -r '.params.folder // ""' < $payload)
 paramRegex=$(jq -r '.params.regex // ""' < $payload)
+skip_download="$(jq -r '.params.skip_download // false' < $payload)"
 
 version=$(jq -r '.version.version // ""' < $payload)
 
@@ -46,6 +47,12 @@ fi
 if [ -z "$version" ]; then
   echo "Missing version"
   exit 1
+fi
+
+if [ "$skip_download" = "true" ]; then
+  echo "Skipping download"
+  jq -n "{ version: { version: $(echo $version | jq -R .) } }" >&3
+  exit 0
 fi
 
 # Building CURL request
@@ -80,3 +87,4 @@ args_url="$endpoint$repository/$file"
 curl $args_security "-O" "$args_url"
 
 echo $file_json | jq '.[].version | {version: {version: .}}' >&3
+

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -84,7 +84,7 @@ check_without_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/check "$src" | tee /dev/stderr
 }
 
@@ -108,7 +108,7 @@ check_with_credentials_with_version() {
       password: $(echo $password | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/check "$src" | tee /dev/stderr
 }
 
@@ -128,7 +128,7 @@ in_without_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/in "$src" | tee /dev/stderr
 }
 
@@ -153,9 +153,34 @@ in_with_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/in "$src" | tee /dev/stderr
 }
+
+# IN
+in_without_credentials_with_version_and_skip_download() {
+
+  local endpoint=$1
+  local regex=$2
+  local folder=$3
+  local version=$4
+  local src=$5
+  local skip_download=$6
+
+  jq -n "{
+    params: {
+      skip_download: $(echo $skip_download | jq -R .)
+    },
+    source: {
+      endpoint: $(echo $endpoint | jq -R .),
+      repository: $(echo $folder | jq -R .),
+      regex: $(echo $regex | jq -R .)
+    },
+    version: { version: $(echo $version| jq -R .)
+    }
+  }" | $resource_dir/in "$src" | tee /dev/stderr
+}
+
 
 # OUT
 deploy_without_credentials() {

--- a/test/test-in.sh
+++ b/test/test-in.sh
@@ -60,8 +60,28 @@ it_can_get_version_from_artifactory_with_credentials() {
 
 }
 
+it_can_skip_download() {
+
+  # local local_ip=$(find_docker_host_ip)
+  #local_ip="localhost"
+
+  artifactory_ip=$ART_IP
+  TMPDIR=/tmp
+
+  local src=$(mktemp -d $TMPDIR/in-src.XXXXXX)
+  local endpoint="http://${artifactory_ip}:8081/artifactory"
+  local regex="ecd-front-(?<version>.*).tar.gz"
+  local folder="/generic/ecd-front"
+  local version="20161109222826"
+  local skip_download="true"
+
+  in_without_credentials_with_version_and_skip_download $endpoint $regex $folder $version $src $skip_download
+
+}
+
 #run it_can_get_version_from_artifactory
 run it_can_get_version_from_artifactory_with_credentials
+run it_can_skip_download
 
 # check for exit code > 0
 #run it_cant_get_version_from_artifactory


### PR DESCRIPTION
Adds the following parameter:
* `skip_download`: *Optional.* skip download of file. Useful for improving put performance by skipping the implicit get step using [get_params](https://concourse.ci/put-step.html#put-step-get-params).

Fixes issue #13.