### PR TITLE
Add disable_redeploy param with tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,21 @@ resources:
 
 ## Source Configuration
 
-* `endpoint`: *Required.* The Artifactory REST API endpoint. eg. http://YOUR-HOST_NAME:8081/artifactory.  
-* `repository`: *Required.* The Artifactory repository which includes any folder path, must contain a leading '/'. ```eg. /generic/product/pcf```  
-* `regex`: *Required.* Regular expression used to extract artifact version, must contain 'version' group. ```E.g. myapp-(?<version>.*).tar.gz```  
-* `username`: *Optional.* Username for HTTP(S) auth when accessing an authenticated repository  
-* `password`: *Optional.* Password for HTTP(S) auth when accessing an authenticated repository  
-* `skip_ssl_verification`: *Optional.* Skip ssl verification when connecting to Artifactory's APIs. Values: ```true``` or ```false```(default).  
+* `endpoint`: *Required.* The Artifactory REST API endpoint. eg. http://YOUR-HOST_NAME:8081/artifactory.
+* `repository`: *Required.* The Artifactory repository which includes any folder path, must contain a leading '/'. ```eg. /generic/product/pcf```
+* `regex`: *Required.* Regular expression used to extract artifact version, must contain 'version' group. ```E.g. myapp-(?<version>.*).tar.gz```
+* `username`: *Optional.* Username for HTTP(S) auth when accessing an authenticated repository
+* `password`: *Optional.* Password for HTTP(S) auth when accessing an authenticated repository
+* `skip_ssl_verification`: *Optional.* Skip ssl verification when connecting to Artifactory's APIs. Values: ```true``` or ```false```(default).
+* `disable_redeploy`: *Optional.* Do not attempt deployment if a matching file version is currently already deployed. This allows jobs to be re-run even if Artifactory is configured to disallow overwriting existing artifacts.
 
 ## Parameter Configuration
 
-* `file`: *Required for put* The file to upload to Artifactory  
-* `regex`: *Optional* overrides the source regex  
-* `folder`: *Optional.* appended to the repository in source - must start with forward slash /  
+* `file`: *Required for put* The file to upload to Artifactory
+* `regex`: *Optional* overrides the source regex
+* `folder`: *Optional.* appended to the repository in source - must start with forward slash /
 
-Saving/deploying an artifact to Artifactory in a pipeline job:  
+Saving/deploying an artifact to Artifactory in a pipeline job:
 
 ``` yaml
   jobs:
@@ -65,7 +66,7 @@ Saving/deploying an artifact to Artifactory in a pipeline job:
       params: { file: ./build/myapp-*.txt }
 ```
 
-Retrieving an artifact from Artifactory in a pipeline job:  
+Retrieving an artifact from Artifactory in a pipeline job:
 
 ``` yaml
 jobs:
@@ -88,7 +89,7 @@ jobs:
         - "Use file(s) from ./file-repository here..."
 ```
 
-See [pipeline.yml](https://github.com/pivotalservices/artifactory-resource/blob/master/pipeline.yml) for an example of a full pipeline definition file.  
+See [pipeline.yml](https://github.com/pivotalservices/artifactory-resource/blob/master/pipeline.yml) for an example of a full pipeline definition file.
 
 ## Resource behavior
 

--- a/assets/out
+++ b/assets/out
@@ -5,7 +5,9 @@ set -e
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
-source $(dirname $0)/common.sh
+resource_dir=$(dirname $0)
+
+source $resource_dir/common.sh
 
 source=$1
 
@@ -25,6 +27,7 @@ regex=$(jq -r '.source.regex // ""' < $payload)
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
 skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
+disable_redeploy=$(jq -r '.source.disable_redeploy // ""' < $payload)
 
 repository=$(jq -r '.source.repository // ""' < $payload)
 folder=$(jq -r '.params.folder // ""' < $payload)
@@ -69,6 +72,59 @@ trueValue="true"
 
 # echo "########## $filename, $file"
 
+if [ "$disable_redeploy" = "true" ]; then
+
+endpoint=$(jq -r '.source.endpoint // ""' < $payload)
+regex=$(jq -r '.source.regex // ""' < $payload)
+username=$(jq -r '.source.username // ""' < $payload)
+password=$(jq -r '.source.password // ""' < $payload)
+skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
+
+repository=$(jq -r '.source.repository // ""' < $payload)
+file=$(jq -r '.params.file // ""' < $payload)
+folder=$(jq -r '.params.folder // ""' < $payload)
+paramRegex=$(jq -r '.params.regex // ""' < $payload)
+
+version=$(jq -r '.version.version // ""' < $payload)
+  foundVersions=$(jq -n \
+  --arg endpoint "$endpoint" \
+  --arg regex "$regex" \
+  --arg username "$username" \
+  --arg password "$password" \
+  --arg skip_ssl_verification "$skip_ssl_verification" \
+  --arg repository "$repository" \
+  --arg file "$file" \
+  --arg folder "$folder" \
+  --arg paramRegex "$paramRegex" \
+  --arg version "$version" \
+  '{
+    version: {
+      version: $version
+    },
+    source: {
+      endpoint: $endpoint,
+      regex: $regex,
+      username: $username,
+      password: $password,
+      skip_ssl_verification: $skip_ssl_verification,
+      repository: $repository
+    },
+    params: {
+      file: $file,
+      folder: $folder,
+      regex: $paramRegex
+    }
+  }' | $resource_dir/check "$source" | jq -r '.[].version')
+
+  for foundVersion in $foundVersions; do
+    if [ "$version" = "$foundVersion" ]; then
+      echo "Skipping deploy because disable_redeploy is enabled and a file matching version of $version is already deployed."
+      jq -n --arg version "$version" '{ version: {version: $version} }' >&3
+      exit 0
+    fi
+  done
+fi
+
 # echo $args_security "-T $abs_file $args_url "
 curl $args_security "-T$abs_file" "$args_url"
 
@@ -79,3 +135,4 @@ version=$(applyRegex_version $regex $filename)
 jq -n "{
   version: {version: $(echo $version | jq -R .)}
 }" >&3
+

--- a/assets/out
+++ b/assets/out
@@ -73,19 +73,6 @@ trueValue="true"
 # echo "########## $filename, $file"
 
 if [ "$disable_redeploy" = "true" ]; then
-
-endpoint=$(jq -r '.source.endpoint // ""' < $payload)
-regex=$(jq -r '.source.regex // ""' < $payload)
-username=$(jq -r '.source.username // ""' < $payload)
-password=$(jq -r '.source.password // ""' < $payload)
-skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
-
-repository=$(jq -r '.source.repository // ""' < $payload)
-file=$(jq -r '.params.file // ""' < $payload)
-folder=$(jq -r '.params.folder // ""' < $payload)
-paramRegex=$(jq -r '.params.regex // ""' < $payload)
-
-version=$(jq -r '.version.version // ""' < $payload)
   foundVersions=$(jq -n \
   --arg endpoint "$endpoint" \
   --arg regex "$regex" \

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -84,7 +84,7 @@ check_without_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/check "$src" | tee /dev/stderr
 }
 
@@ -108,7 +108,7 @@ check_with_credentials_with_version() {
       password: $(echo $password | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/check "$src" | tee /dev/stderr
 }
 
@@ -128,7 +128,7 @@ in_without_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/in "$src" | tee /dev/stderr
 }
 
@@ -153,7 +153,7 @@ in_with_credentials_with_version() {
       regex: $(echo $regex | jq -R .)
     },
     version: { version: $(echo $version| jq -R .)
-    }  
+    }
   }" | $resource_dir/in "$src" | tee /dev/stderr
 }
 
@@ -211,5 +211,32 @@ deploy_with_credentials() {
     }
   }
 EOF
+}
+
+# OUT
+deploy_without_credentials_and_skip_redeploy() {
+
+  local endpoint=$1
+  local regex=$2
+  local repository=$3
+  local file=$(create_file "$6" "$4")
+  local version=$5
+  local src=$6
+  local skip_redeploy=$7
+
+  local version_file=$(create_version_file "$version" "$src")
+
+  jq -n "{
+    params: {
+      file: $(echo $file | jq -R .),
+      version_file: $(echo $version_file | jq -R .)
+    },
+    source: {
+      endpoint: $(echo $endpoint | jq -R .),
+      repository: $(echo $repository | jq -R .),
+      regex: $(echo $regex | jq -R .),
+      skip_redeploy: $(echo $skip_redeploy | jq -R .)
+    }
+  }" | $resource_dir/out "$src" | tee /dev/stderr
 }
 

--- a/test/test-out.sh
+++ b/test/test-out.sh
@@ -48,5 +48,32 @@ it_can_deploy_release_to_artifactory_with_credentials() {
   deploy_with_credentials $endpoint $regex $repository $file $version $src $username $password
 }
 
+it_can_skip_redeploying_existing_release_to_artifactory() {
+
+  # local local_ip=$(find_docker_host_ip)
+  #local_ip=localhost
+
+  artifactory_ip=$ART_IP
+  TMPDIR=/tmp
+
+  local src=$(mktemp -d $TMPDIR/in-src.XXXXXX)
+  local endpoint="http://${artifactory_ip}:8081/artifactory"
+  local regex="ecd-front-(?<version>.*).tar.gz"
+  local folder="/generic/ecd-front"
+  local version="20161109222826"
+  local username="${ART_USER}"
+  local password="${ART_PWD}"
+  local skip_redeploy="true"
+
+  local repository="/generic/ecd-front"
+  local file="ecd-front-(?<version>.*).tar.gz"
+
+  local version=20161109222826
+
+  deploy_without_credentials_and_skip_redeploy $endpoint $regex $repository $file $version $src $skip_redeploy
+}
+
 run it_can_deploy_release_to_artifactory_with_credentials
 run it_can_deploy_release_to_artifactory
+run it_can_skip_redeploying_existing_release_to_artifactory
+


### PR DESCRIPTION
Adds the following parameter:

* `disable_redeploy`: *Optional.* Do not attempt deployment if a matching file version is currently already deployed. This allows jobs to be re-run even if Artifactory is configured to disallow overwriting existing artifacts.
