### PR TITLE
Send file checksum on upload

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -72,7 +72,7 @@ trueValue="true"
 # NOTE: X-Checksum-Sha256 is currently broken. See https://www.jfrog.com/jira/browse/RTFACT-9871
 args_checksums=" \
 --header X-Checksum-MD5:$(md5sum $abs_file | awk '{print $1}') \
---header X-Checksum-Sha1:$(shasum -a 1 $abs_file | awk '{ print $1 }') \
+--header X-Checksum-Sha1:$(sha1sum $abs_file | awk '{ print $1 }') \
 ";
 
 # echo $args_security $args_checksums "-T$abs_file" "$args_url"

--- a/assets/out
+++ b/assets/out
@@ -69,8 +69,14 @@ trueValue="true"
 
 # echo "########## $filename, $file"
 
-# echo $args_security "-T $abs_file $args_url "
-curl $args_security "-T$abs_file" "$args_url"
+# NOTE: X-Checksum-Sha256 is currently broken. See https://www.jfrog.com/jira/browse/RTFACT-9871
+args_checksums=" \
+--header X-Checksum-MD5:$(md5sum $abs_file | awk '{print $1}') \
+--header X-Checksum-Sha1:$(shasum -a 1 $abs_file | awk '{ print $1 }') \
+";
+
+# echo $args_security $args_checksums "-T$abs_file" "$args_url"
+curl $args_security $args_checksums "-T$abs_file" "$args_url"
 
 
 # echo $file $regex
@@ -79,3 +85,4 @@ version=$(applyRegex_version $regex $filename)
 jq -n "{
   version: {version: $(echo $version | jq -R .)}
 }" >&3
+


### PR DESCRIPTION
This PR sends checksums of the uploaded file to Artifactory which will verify that the uploaded file is uncorrupted. As maintaining file integrity is a universally desired feature I see no reason to make it optional, but I'm willing to make that change if someone can find a need for it. Another need for this feature is that some repository types such as Maven often require that checksums be set for artifacts which they download.