### PR TITLE
Store metadata (version and download URI) after retrieving artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ resources:
     username: YOUR-ARTIFACTORY-USERNAME
     password: YOUR-ARTIFACTORY-PASSWORD
     skip_ssl_verification: true
+    metadata: true
 ```
 
 ## Source Configuration
@@ -31,6 +32,7 @@ resources:
 * `username`: *Optional.* Username for HTTP(S) auth when accessing an authenticated repository  
 * `password`: *Optional.* Password for HTTP(S) auth when accessing an authenticated repository  
 * `skip_ssl_verification`: *Optional.* Skip ssl verification when connecting to Artifactory's APIs. Values: ```true``` or ```false```(default).  
+* `metadata`: *Optional.* If true, it creates `.artifactory/version` and `.artifactory/uri` files after retrieving artifact, allowing to use version and download URL in another tasks.
 
 ## Parameter Configuration
 

--- a/assets/in
+++ b/assets/in
@@ -25,6 +25,7 @@ regex=$(jq -r '.source.regex // ""' < $payload)
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)
 skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // ""' < $payload)
+metadata=$(jq -r '.source.metadata // false' < $payload)
 
 repository=$(jq -r '.source.repository // ""' < $payload)
 file=$(jq -r '.params.file // ""' < $payload)
@@ -78,5 +79,11 @@ args_url="$endpoint$repository/$file"
 
 # echo $args_security "-O" "$args_url"
 curl $args_security "-O" "$args_url"
+
+if [ "$metadata" = "true" ]; then
+  mkdir .artifactory
+  echo "$args_url" > .artifactory/uri
+  echo "$version" > .artifactory/version
+fi
 
 echo $file_json | jq '.[].version | {version: {version: .}}' >&3


### PR DESCRIPTION
This PR adds for 'in' option to write metadata (in '.artifactory' folder, similar to GIT) alongside to downloaded file. It can be later utilized in other tasks/resources. Currently it creates 'version' and 'uri' files ('uri' is full URL to retrieve artifact so may be published somewhere).